### PR TITLE
Speed up unit-test CI by removing redundant full build step

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,29 @@
+name: Build Check
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build_check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build all targets and run lint
+      run: ./gradlew assemble :multipaz-compose:lint

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  build_and_test:
+  test:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
@@ -26,8 +26,6 @@ jobs:
         cache: gradle
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build -x test
     - name: Run unit tests
       run: ./gradlew test
 #    - name: Enable KVM


### PR DESCRIPTION
## Summary
- Remove the `./gradlew build -x test` step from unit-test.yml which compiled all targets (~35 min) before running tests (~38 sec). The `test` task already compiles what it needs.
- Add a separate nightly `build-check.yml` workflow for full production build + lint verification.

## Expected results
- PR feedback: ~6 min (down from ~35 min)
- Full build verification: runs nightly + manually triggerable

## Test plan
- [ ] Verify the `test` job completes in ~6 minutes
- [ ] Manually trigger the `build-check` workflow and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)